### PR TITLE
gettextを依存に追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM circleci/python:3.6-stretch-browsers
 LABEL maintainer="OLTA"
-RUN sudo apt install fonts-ipafont fonts-ipaexfont
+RUN sudo apt install fonts-ipafont fonts-ipaexfont gettext


### PR DESCRIPTION
## 概要

* circle.yml の中で `python manage.py compilemessages` を呼び出す際、 gettext のコマンドが必要になるので、パッケージを追加しました。