### PR TITLE
Change the base image so it will contain node.js by default.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
-FROM circleci/python:3.6-stretch-browsers
+FROM circleci/python:3.6-stretch-node-browsers
 LABEL maintainer="OLTA"
-RUN sudo apt install fonts-ipafont fonts-ipaexfont gettext
+USER root
+RUN apt-get -qy update && apt-get -qy install fonts-ipafont fonts-ipaexfont gettext
+USER circleci


### PR DESCRIPTION
## 概要

* CircleCIで利用するベースイメージに、あらかじめ node.js (v10.x) が入るようにしました。
* CIの実行が速くなります。