### PR TITLE
Migrate to Python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM circleci/python:3.6-stretch-node-browsers
+FROM circleci/python:3.8-buster-node-browsers
 LABEL maintainer="OLTA"
 USER root
-RUN apt-get -qy update && apt-get -qy install fonts-ipafont fonts-ipaexfont gettext
+RUN apt-get -qy update && apt-get -qy install fonts-ipafont fonts-ipaexfont gettext && apt-get clean && rm -rf /var/lib/apt/lists
 USER circleci


### PR DESCRIPTION
## 概要

* Pythonのバージョンを3.8に上げます
* イメージを小さくするために `apt-get clean` と `rm -rf /var/lib/apt/lists` を追加